### PR TITLE
Add dispatch workflow and manifest to deploy persistent volumes for MongoDB database

### DIFF
--- a/.github/actions/interpolate-manifest-secrets/action.yml
+++ b/.github/actions/interpolate-manifest-secrets/action.yml
@@ -1,0 +1,16 @@
+name: Interpolate Actions Secrets into Manifest
+
+inputs:
+  manifest:
+    required: true
+  file-share-base-name:
+    default: FILE_SHARE_BASE_NAME
+
+runs:
+  using: composite
+  steps:
+    - run: |
+        sed -i \
+          -e "s/FILE_SHARE_BASE_NAME/${{ inputs.file-share-base-name }}/" \
+          ${{ inputs.manifest }}
+      shell: bash

--- a/.github/workflows/deploy-mongo-volumes.yml
+++ b/.github/workflows/deploy-mongo-volumes.yml
@@ -1,0 +1,45 @@
+name: Deploy Database Persistent Volumes
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Persistent Volumes Deployment
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Git branch
+        uses: actions/checkout@v3
+
+      - name: Login to Azure
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Set Azure Kubernetes Service configuration
+        uses: azure/aks-set-context@v3
+        with:
+          resource-group: ${{ secrets.RESOURCE_GROUP }}
+          cluster-name: ${{ secrets.CLUSTER_NAME }}
+
+      - name: Interpolate secrets into deployment manifest
+        uses: ./.github/actions/interpolate-manifest-secrets
+        with:
+          manifest: manifests/mongo-volumes.yml
+          file-share-base-name: ${{ secrets.FILE_SHARE_BASE_NAME }}
+
+      - name: Deploy persistent volumes for database
+        uses: Azure/k8s-deploy@v4
+        with:
+          action: deploy
+          manifests: |
+            manifests/mongo-volumes.yml
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v3
+
+      - name: Wait for volumes to become available
+        run: |
+          kubectl wait -f manifests/mongo-volumes.yml \
+            --for=jsonpath='{.status.phase}'=Available --timeout=300s

--- a/manifests/mongo-volumes.yml
+++ b/manifests/mongo-volumes.yml
@@ -1,0 +1,87 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: mongo-vol1
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: azurefile-csi
+  mountOptions:
+    - dir_mode=0777
+    - file_mode=0777
+    - uid=0
+    - gid=0
+    - mfsymlinks
+    - cache=strict
+    - nosharesock
+  csi:
+    driver: file.csi.azure.com
+    readOnly: false
+    volumeHandle: mongo-vol1
+    volumeAttributes:
+      shareName: FILE_SHARE_BASE_NAME1
+    nodeStageSecretRef:
+      name: azure-secret
+      namespace: default
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: mongo-vol2
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: azurefile-csi
+  mountOptions:
+    - dir_mode=0777
+    - file_mode=0777
+    - uid=0
+    - gid=0
+    - mfsymlinks
+    - cache=strict
+    - nosharesock
+  csi:
+    driver: file.csi.azure.com
+    readOnly: false
+    volumeHandle: mongo-vol2
+    volumeAttributes:
+      shareName: FILE_SHARE_BASE_NAME2
+    nodeStageSecretRef:
+      name: azure-secret
+      namespace: default
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: mongo-vol3
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: azurefile-csi
+  mountOptions:
+    - dir_mode=0777
+    - file_mode=0777
+    - uid=0
+    - gid=0
+    - mfsymlinks
+    - cache=strict
+    - nosharesock
+  csi:
+    driver: file.csi.azure.com
+    readOnly: false
+    volumeHandle: mongo-vol3
+    volumeAttributes:
+      shareName: FILE_SHARE_BASE_NAME3
+    nodeStageSecretRef:
+      name: azure-secret
+      namespace: default


### PR DESCRIPTION
As the Kubernetes persistent volumes required for the MongoDB database should be deployed in advance of database and application deployments, and persist across them, add a dispatch workflow and accompanying manifest to perform the deployment of the volumes only when triggered by an administrative dispatch event.

This GitHub Actions workflow expects an Azure Kubernetes Service cluster to exist and for its name and resource group to be configured as GitHub Actions secrets.

The workflow also expects Azure File Shares for the volumes to exist and to be named with a common base name followed by an ordinal number.  The base name will be interpolated with a GitHub Actions secret which will replace the `FILE_SHARE_BASE_NAME` string in the manifest.  This secret must be also configured in GitHub Actions, along with the Azure login credentials.

After deployment of the persistent volumes manifest, the workflow uses `kubectl` to wait for the volumes' statuses to reach the available phase.

The manifest defines three Kubernetes persistent volumes, each using a distinct Azure File Share; these will be bound via persistent volume claims to the three replicas in the stateful set of pods that will run MongoDB.

Using persistent volumes ensures that the underlying filesystems in the File Shares are maintained across redeployments of the MongoDB database; otherwise, data would be lost and the database would likely enter a corrupt state.

The volume's reclaim policy is set to the "retain" mode to ensure they are not deleted when the claims to them are released, should the MongoDB pods be stopped, although this should not happen since these volumes are deployed statically not dynamically.

A helper composite action is created to replace the `FILE_SHARE_BASE_NAME` string in the manifest with the common base name of all Azure File Shares; this helper can be extended in future PRs.