### PR TITLE
Add dispatch workflow and manifest to deploy stateful set for MongoDB database

### DIFF
--- a/.github/actions/azure-login-setup/action.yml
+++ b/.github/actions/azure-login-setup/action.yml
@@ -1,0 +1,37 @@
+name: Azure Login and Setup
+
+inputs:
+  credentials:
+    required: true
+  resource-group:
+    required: true
+  cluster-name:
+    required: true
+  registry-login-server:
+    required: true
+  registry-username:
+    required: true
+  registry-password:
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Login to Azure
+      uses: azure/login@v1
+      with:
+        creds: ${{ inputs.credentials }}
+
+    - name: Set Azure Kubernetes Service configuration
+      uses: azure/aks-set-context@v3
+      with:
+        resource-group: ${{ inputs.resource-group }}
+        cluster-name: ${{ inputs.cluster-name }}
+
+    - name: Create Azure container registry secret
+      uses: azure/k8s-create-secret@v4
+      with:
+        container-registry-url: ${{ inputs.registry-login-server }}
+        container-registry-username: ${{ inputs.registry-username }}
+        container-registry-password: ${{ inputs.registry-password }}
+        secret-name: k8s-secret

--- a/.github/workflows/deploy-mongo-statefulset.yml
+++ b/.github/workflows/deploy-mongo-statefulset.yml
@@ -1,0 +1,72 @@
+name: Deploy Database Stateful Set
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Git branch
+        uses: actions/checkout@v3
+
+      - name: Login to Azure and set AKS and registry configuration
+        uses: ./.github/actions/azure-login-setup
+        with:
+          credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          resource-group: ${{ secrets.RESOURCE_GROUP }}
+          cluster-name: ${{ secrets.CLUSTER_NAME }}
+          registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          registry-username: ${{ secrets.REGISTRY_USERNAME }}
+          registry-password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Login to Azure Docker container registry
+        uses: azure/docker-login@v1
+        with:
+          login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Deploy stateful set for database
+        uses: azure/k8s-deploy@v4
+        with:
+          action: deploy
+          manifests: |
+            manifests/mongo-statefulset.yml
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v3
+
+      - name: Wait for stateful set pod readiness
+        run: |
+          kubectl wait pods \
+            --selector role=mongo --for condition=ready --timeout=300s
+
+      - name: Create or update MongoDB replica set
+        run: |
+          cat <<EOF | kubectl exec -it mongo-0 -- mongosh mongodb://mongo-0.mongo
+            rs.initiate();
+            cfg = rs.conf();
+            cfg.members[0].host = "mongo-0.mongo:27017";
+            rs.reconfig(cfg, {force: true});
+            sleep(10000);
+            rs.add("mongo-1.mongo:27017");
+            sleep(10000);
+            rs.add("mongo-2.mongo:27017");
+            sleep(10000);
+          EOF
+
+      - name: Check MongoDB replica set status
+        run: |
+          kubectl exec -it mongo-0 -- mongosh mongodb://mongo-0.mongo --eval "rs.status();" >status.out
+          cat status.out
+          test $(grep -c PRIMARY status.out) -eq 1
+          test $(grep -c SECONDARY status.out) -eq 2
+
+      - name: Create or update default MongoDB database
+        run: |
+          cat <<EOF | kubectl exec -it mongo-0 -- mongosh mongodb://mongo-0.mongo
+            use db;
+            db.deployment.updateOne({version: "latest"}, {\$set: {time: "$(date +%s)"}}, {upsert: true});
+          EOF

--- a/manifests/mongo-statefulset.yml
+++ b/manifests/mongo-statefulset.yml
@@ -1,0 +1,54 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongo
+  labels:
+    name: mongo
+spec:
+  ports:
+    - port: 27017
+      targetPort: 27017
+  selector:
+    role: mongo
+  clusterIP: None
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mongo
+spec:
+  selector:
+    matchLabels:
+      role: mongo
+  serviceName: "mongo"
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        role: mongo
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: mongo
+        image: mongo
+        command:
+          - mongod
+          - "--bind_ip_all"
+          - "--replSet"
+          - rs0
+        ports:
+          - containerPort: 27017
+        volumeMounts:
+          - name: mongo-persistent-storage
+            mountPath: /data/db
+  volumeClaimTemplates:
+    - metadata:
+        name: mongo-persistent-storage
+      spec:
+        storageClassName: azurefile-csi
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi


### PR DESCRIPTION
As the Kubernetes stateful set of pods required for the MongoDB database should be deployed in advance of application deployments, and persist across them, add a dispatch workflow to perform the deployment of the stateful set only when triggered by an administrative dispatch event.

This GitHub Actions workflow expects an Azure Kubernetes Service cluster to exist and for its name and resource group to be configured as GitHub Actions secrets.  It also expects an Azure Docker container registry to exist and for its name and credentials to be configured as GitHub Actions secrets.

As well, the workflow expects a set of three persistent volumes to exist to be claimed by the stateful set's pods.  See PR #1 for the manifest and dispatch workflow to create those.

The manifest defines a Kubernetes stateful set of three replica pods, each running MongoDB and bound to a persistent volume which is mounted at `/data/db` so the database files will be persisted across pod 
redeployments; otherwise, data would be lost and the database would likely enter a corrupt state.

The use of a stateful set ensures that when a pod fails, the replacement pod will be bound to the same volume, and will have the same identifier so application clients and other pods' database processes can connect to it at the same address.  The default update strategy for a stateful set is the rolling update strategy, so each pod is updated in turn without overlap.

The manifest also defines a headless service by setting the cluster IP value to `None`; this form of service is required by stateful sets so that the pods are assigned fixed network identities.

The MongoDB database processes bind to all available addresses and listen on the standard MongoDB port 27017, so they will be available at, for instance, `mongo-0.mongo:27017`, `mongo-1.mongo:27017`, etc.

After deployment of the stateful set manifest, the new workflow uses `kubectl` to wait for the pods to reach the ready condition.

Once that state has been reached, the workflow job creates or updates the MongoDB replica set (which is a distinct concept from a Kubernetes replica set), using `kubectl` to execute the `mongosh` interactive shell.  If the replica set has been initiated previously MongoDB will report an error message but proceed without halting.

All three pods defined by the manifest will be registered in the MongoDB replica set, using their internal DNS addresses of `mongo-1.mongo`, `mongo-2.mongo`, etc.  If any have been registered previously, MongoDB will report the issue and ignore the new registrations.

After waiting for the registrations to complete, the job uses `kubectl` and `mongosh` to check the status of the MongoDB replica set; there should be one primary database replica and two secondaries.

Finally, the job creates the default `db` database in MongoDB, if it does not exist, by inserting a timestamp row.  In the case where the database has been deployed before, this step updates the timestamp instead.

Several GitHub Actions workflows, including this one, will perform a common series of steps to login to Azure, setup the Azure Kubernetes Service cluster configuration settings, and create a container registry secret, so a helper action consolidates those steps into a single composite action, which will simplify the calling workflows.