### PR TITLE
Add dispatch workflow and manifest to deploy application load balancer service

### DIFF
--- a/.github/workflows/deploy-app-service.yml
+++ b/.github/workflows/deploy-app-service.yml
@@ -1,0 +1,39 @@
+name: Deploy Application Load Balancer
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Load Balancer Service Deployment
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Git branch
+        uses: actions/checkout@v3
+
+      - name: Login to Azure
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Set Azure Kubernetes Service configuration
+        uses: azure/aks-set-context@v3
+        with:
+          resource-group: ${{ secrets.RESOURCE_GROUP }}
+          cluster-name: ${{ secrets.CLUSTER_NAME }}
+
+      - name: Deploy application load balancer service
+        uses: Azure/k8s-deploy@v4
+        with:
+          action: deploy
+          manifests: |
+            manifests/app-service.yml
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v3
+
+      - name: Wait for service ingress IP assignment
+        run: |
+          timeout 300s sh \
+            -c 'until kubectl get service frontend --output=jsonpath='{.status.loadBalancer}' | grep ingress; do : ; done'

--- a/manifests/app-service.yml
+++ b/manifests/app-service.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 8081
+  selector:
+    role: frontend


### PR DESCRIPTION
As the Kubernetes load balancer service for the mongo-express application does not require redeployment on every application change, add a dispatch workflow to perform the deployment of the load balancer service only when triggered by an administrative dispatch event.
    
This GitHub Actions workflow expects an Azure Kubernetes Service cluster to exist and for its name and resource group to be configured as GitHub Actions secrets, as well as the Azure login credentials.

This manifest defines a Kubernetes load balancer service across all application pods with the `role` label of `frontend`.  The balancer will listen on port 80 and forward requests to the pods on port 8081.  Pods are selected if they also have the `role` label of `frontend` as well.

After deployment of the persistent volumes manifest, the workflow uses `kubectl` to wait for the service's ingress IP to be assigned.  Unfortunately this can not be done exclusively with the `kubectl wait` command as its JSON condition matching requires a fixed string, and the IP address cannot be known in advance.  Instead, use `kubectl get` in a loop and wait for the load balancer's status to contain an `ingress` key, as suggested in this [comment](https://github.com/kubernetes/kubernetes/issues/80828#issuecomment-979054581).  See also this [concern](https://github.com/kubernetes/kubernetes/issues/83094#issuecomment-1464809824) regarding how JSON condition matching was implemented for `kubectl wait`.