### PR TITLE
Add default branch push workflow and manifest to deploy and approve application

### DIFF
--- a/.github/actions/interpolate-manifest-secrets/action.yml
+++ b/.github/actions/interpolate-manifest-secrets/action.yml
@@ -5,6 +5,16 @@ inputs:
     required: true
   file-share-base-name:
     default: FILE_SHARE_BASE_NAME
+  registry-login-server:
+    default: REGISTRY_LOGIN_SERVER
+  app-cookie-secret:
+    default: APP_COOKIE_SECRET
+  app-session-secret:
+    default: APP_SESSION_SECRET
+  app-admin-username:
+    default: APP_ADMIN_USERNAME
+  app-admin-password:
+    default: APP_ADMIN_PASSWORD
 
 runs:
   using: composite
@@ -12,5 +22,10 @@ runs:
     - run: |
         sed -i \
           -e "s/FILE_SHARE_BASE_NAME/${{ inputs.file-share-base-name }}/" \
+          -e "s/REGISTRY_LOGIN_SERVER/${{ inputs.registry-login-server }}/" \
+          -e "s/APP_COOKIE_SECRET/${{ inputs.app-cookie-secret }}/" \
+          -e "s/APP_SESSION_SECRET/${{ inputs.app-session-secret }}/" \
+          -e "s/APP_ADMIN_USERNAME/${{ inputs.app-admin-username }}/" \
+          -e "s/APP_ADMIN_PASSWORD/${{ inputs.app-admin-password }}/" \
           ${{ inputs.manifest }}
       shell: bash

--- a/.github/workflows/deploy-app-deployment.yml
+++ b/.github/workflows/deploy-app-deployment.yml
@@ -1,0 +1,242 @@
+name: Deploy Application and Approve
+
+on:
+  push:
+    branches:
+      - demo
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  test:
+    name: Build and Test Application
+    runs-on: ubuntu-latest
+
+    services:
+      mongodb:
+        image: mongo
+        ports:
+          - 27017:27017
+
+    steps:
+      - name: Checkout Git branch
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build application
+        run: yarn build
+
+      - name: Test application
+        run: yarn mocha
+
+      - name: Lint application code
+        run: yarn lint
+
+  build:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - name: Checkout Git branch
+        uses: actions/checkout@v3
+
+      - name: Login to Azure
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Login to Azure Docker container registry
+        uses: azure/docker-login@v1
+        with:
+          login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build and push application Docker image
+        run: |
+          docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/mongo-express:${{ github.sha }}
+          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/mongo-express:${{ github.sha }}
+
+  canary:
+    name: Canary Deployment
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Checkout Git branch
+        uses: actions/checkout@v3
+
+      - name: Login to Azure and set AKS and registry configuration
+        uses: ./.github/actions/azure-login-setup
+        with:
+          credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          resource-group: ${{ secrets.RESOURCE_GROUP }}
+          cluster-name: ${{ secrets.CLUSTER_NAME }}
+          registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          registry-username: ${{ secrets.REGISTRY_USERNAME }}
+          registry-password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Interpolate secrets into deployment manifest
+        uses: ./.github/actions/interpolate-manifest-secrets
+        with:
+          manifest: manifests/app-deployment.yml
+          registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          app-cookie-secret: ${{ secrets.APP_COOKIE_SECRET }}
+          app-session-secret: ${{ secrets.APP_SESSION_SECRET }}
+          app-admin-username: ${{ secrets.APP_ADMIN_USERNAME }}
+          app-admin-password: ${{ secrets.APP_ADMIN_PASSWORD }}
+
+      - name: Deploy canary and baseline pods
+        uses: azure/k8s-deploy@v4
+        with:
+          action: deploy
+          strategy: canary
+          percentage: 34  # With three replicas defined by the manifest,
+                          # this calculates floor(34 * 3 / 100) = 1, so
+                          # one baseline and one canary replica are added to
+                          # the existing stable deployment, meaning the actual
+                          # canary percentage is only 20%.
+          manifests: |
+            manifests/app-deployment.yml
+          images: |
+            ${{ secrets.REGISTRY_LOGIN_SERVER }}/mongo-express:${{ github.sha }}
+          imagepullsecrets: |
+            k8s-secret
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v3
+
+      - name: Wait for canary and baseline pod readiness
+        run: |
+          kubectl wait pods \
+            --selector 'role=frontend,workflow/version in (baseline,canary)' \
+            --for=condition=ready --timeout=300s
+
+  approve:
+    name: Approve Canary Deployment
+    runs-on: ubuntu-latest
+    needs: canary
+    environment: demo
+
+    steps:
+      - name: Wait for approval of canary deployment
+        run: echo "Waiting for approval of canary deployment"
+
+  promote:
+    name: Promote to Full Deployment
+    runs-on: ubuntu-latest
+    needs: approve
+
+    steps:
+      - name: Checkout Git branch
+        uses: actions/checkout@v3
+
+      - name: Login to Azure and set AKS and registry configuration
+        uses: ./.github/actions/azure-login-setup
+        with:
+          credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          resource-group: ${{ secrets.RESOURCE_GROUP }}
+          cluster-name: ${{ secrets.CLUSTER_NAME }}
+          registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          registry-username: ${{ secrets.REGISTRY_USERNAME }}
+          registry-password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Interpolate secrets into deployment manifest
+        uses: ./.github/actions/interpolate-manifest-secrets
+        with:
+          manifest: manifests/app-deployment.yml
+          registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          app-cookie-secret: ${{ secrets.APP_COOKIE_SECRET }}
+          app-session-secret: ${{ secrets.APP_SESSION_SECRET }}
+          app-admin-username: ${{ secrets.APP_ADMIN_USERNAME }}
+          app-admin-password: ${{ secrets.APP_ADMIN_PASSWORD }}
+
+      - name: Perform full deployment
+        uses: azure/k8s-deploy@v4
+        with:
+          action: promote
+          strategy: canary
+          percentage: 34
+          manifests: |
+            manifests/app-deployment.yml
+          images: |
+            ${{ secrets.REGISTRY_LOGIN_SERVER }}/mongo-express:${{ github.sha }}
+          imagepullsecrets: |
+            k8s-secret
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v3
+
+      - name: Wait for canary deployment pod cleanup
+        run: |
+          kubectl wait pods \
+            --selector 'role=frontend,workflow/version in (baseline,canary)' \
+            --for=delete --timeout=300s
+
+      - name: Check full deployment pod readiness
+        run: |
+          kubectl wait pods --selector role=frontend --for condition=ready --timeout=300s
+
+  revert:
+    name: Revert to Stable Deployment
+    runs-on: ubuntu-latest
+    needs: approve
+    if: ${{ failure() }}
+
+    steps:
+      - name: Checkout Git branch
+        uses: actions/checkout@v3
+
+      - name: Login to Azure and set AKS and registry configuration
+        uses: ./.github/actions/azure-login-setup
+        with:
+          credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          resource-group: ${{ secrets.RESOURCE_GROUP }}
+          cluster-name: ${{ secrets.CLUSTER_NAME }}
+          registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          registry-username: ${{ secrets.REGISTRY_USERNAME }}
+          registry-password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Interpolate secrets into deployment manifest
+        uses: ./.github/actions/interpolate-manifest-secrets
+        with:
+          manifest: manifests/app-deployment.yml
+          registry-login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          app-cookie-secret: ${{ secrets.APP_COOKIE_SECRET }}
+          app-session-secret: ${{ secrets.APP_SESSION_SECRET }}
+          app-admin-username: ${{ secrets.APP_ADMIN_USERNAME }}
+          app-admin-password: ${{ secrets.APP_ADMIN_PASSWORD }}
+
+      - name: Revert to stable deployment
+        uses: azure/k8s-deploy@v4
+        with:
+          action: reject
+          strategy: canary
+          percentage: 34
+          manifests: |
+            manifests/app-deployment.yml
+          images: |
+            ${{ secrets.REGISTRY_LOGIN_SERVER }}/mongo-express:${{ github.sha }}
+          imagepullsecrets: |
+            k8s-secret
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v3
+
+      - name: Wait for canary deployment pod cleanup
+        run: |
+          kubectl wait pods \
+            --selector 'role=frontend,workflow/version in (baseline,canary)' \
+            --for=delete --timeout=300s
+
+      - name: Check stable deployment pod readiness
+        run: |
+          kubectl wait pods --selector role=frontend --for condition=ready --timeout=300s

--- a/manifests/app-deployment.yml
+++ b/manifests/app-deployment.yml
@@ -1,0 +1,55 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    role: frontend
+spec:
+  selector:
+    matchLabels:
+      role: frontend
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        role: frontend
+    spec:
+      containers:
+      - name: frontend
+        image: REGISTRY_LOGIN_SERVER/mongo-express
+        env:
+        - name: VCAP_APP_HOST
+          value: 0.0.0.0
+        - name: ME_CONFIG_MONGODB_URL
+          value: mongodb://mongo-0.mongo,mongo-1.mongo,mongo-2.mongo/db
+        - name: ME_CONFIG_SITE_COOKIESECRET
+          value: APP_COOKIE_SECRET
+        - name: ME_CONFIG_SITE_SESSIONSECRET
+          value: APP_SESSION_SECRET
+        - name: ME_CONFIG_BASICAUTH
+          value: "true"
+        - name: ME_CONFIG_BASICAUTH_USERNAME
+          value: APP_ADMIN_USERNAME
+        - name: ME_CONFIG_BASICAUTH_PASSWORD
+          value: APP_ADMIN_PASSWORD
+        ports:
+          - containerPort: 8081
+        readinessProbe:
+          httpGet:
+             path: /status
+             port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+        livenessProbe:
+          httpGet:
+            path: /status
+            port: 8081
+          initialDelaySeconds: 10
+          periodSeconds: 10


### PR DESCRIPTION
This GitHub actions workflow runs on every push merged into the default `demo` branch, and will build, test, and deploy the application, with an explicit manual approval required after an initial canary deployment to 20% of the application's pods.

This GitHub Actions workflow expects an Azure Kubernetes Service cluster to exist and for its name and resource group to be configured as GitHub Actions secrets.  It also expects an Azure Docker container registry to exist and for its name and credentials to be configured as GitHub Actions secrets.

The general Azure credentials must also be configured as GitHub Actions secrets, as well as a set of application configuration values, including the application's cookie-signed secrets and the login and password it should require from users.

The manifest defines a Kubernetes deployment for three application pods with the `role` label of `frontend`, to which the load balancer service will direct traffic on port 8081.

The rolling update strategy is used so pods will be redeployed incrementally with no downtime.  No more than one extra pod is allowed at any time, and no more than one pod may be unavailable at any time.

Application liveness and readiness checks are defined using the application's health status URL path.
    
The Docker image for the application is expected to be available in an Azure container registry whose name should be interpolated into the manifest in place of the `REGISTRY_LOGIN_SERVER` string by the deployment GitHub Actions workflow.

The workflow should also interpolate a series of configuration values for the application itself, including the secrets used to sign the application's cookies and the login and password for the application.

The workflow's initial test job is derived from the existing upstream mongo-express project's standard CI test workflow.

The subsequent job builds a Docker image of the application and pushes it into the Azure container registry.

If this succeeds, the next job deploys the built Docker image to a canary pod, to which the load balancer will route 20% of the overall application traffic.  Note that the `azure/k8s-deploy` [action](https://github.com/azure/k8s-deploy)'s canary strategy calculates the number of canary and baseline pods to be added to the existing set such that the requested input traffic percentage does not match the actual percentage.  Because the manifest defines a deployment of three pods, given an input percentage of 34%, the action calculates floor(34 × 3 / 100) = 1, so one baseline and one canary replica are then added to the existing deployment.  This results in an actual percentage of traffic routed to the canary pod of 20%.  Note also that the baseline pod simply runs the existing deployed image of the application, not the new image.

After the canary deployment of the manifest and the new Docker image, the workflow uses `kubectl` to wait for the new canary and baseline pods to reach the ready condition.

Upon a successful canary deployment, the workflow then pauses for explicit manual review of the health of the application and approval to proceed with a full deployment, assuming the `demo` environment has been configured with required reviewers for any deployment.

If approval is not granted, the next job is skipped and the final job runs to roll back the canary deployment by deleting the canary and baseline pods.

If approval is granted, however, the final job is skipped and the workflow instead proceeds with a job to complete the full deployment.  The normal pods will be replaced with ones running the new Docker image, according to the rolling update strategy defined in the manifest, and the baseline and canary pods will be deleted.

Both of these jobs use `kubectl` to wait for the canary and baseline pods to be deleted, and for the remaining pods to reach the ready condition.  In the rollback case, these pods should be untouched and already in this condition.

In commit 03665ad3e7fbfa1dfff358a8e056269dfc49522a of PR #1 a utility composite action was added to allow calling GitHub Actions workflows to interpolate GitHub Actions secrets into Kubernetes manifest files.  In order to support the application pod deployment manifest, a set of five new inputs are defined for the helper action, including the Azure container registry name and the application's cookie-signing secrets and login and password.