### PR TITLE
Suppress internal MongoDB databases in application UI

### DIFF
--- a/config.default.js
+++ b/config.default.js
@@ -131,7 +131,7 @@ export default {
     whitelist: [],
 
     // blacklist: hide databases listed in the blacklist (empty list for no blacklist)
-    blacklist: [],
+    blacklist: ['admin', 'config', 'local'],
   },
 
   site: {


### PR DESCRIPTION
Suppress the `admin`, `config`, and `local` internal MongoDB databases from appearing the application's user interface.